### PR TITLE
feat: link to wikivoyage tour guide on index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -135,9 +135,9 @@ Next to the train station "Mundsburg" is one of Hamburgs largest shopping malls 
 <div class="content-section" markdown="1">
 ## Hamburg
 
-If you are the first time in Hamburg we have some tipps for getting around here and what you should probably visit while being here.
+Getting to Hamburg is easy - the Wikivoyage travel guide sums up everything you need to know about getting to and getting around Hamburg, finding a place to stay or even moving here: [Wikivoyage - Hamburg](https://en.wikivoyage.org/wiki/Hamburg)
 
-Having some days left before or after Ruby Unconf? [Hamburg is beautiful <3]({{site.baseurl}}{% link sightseeing.md %})
+If you are the first time in Hamburg we have some tipps for getting around here and what you should probably visit while being here. Having some days left before or after Ruby Unconf? [Hamburg is beautiful <3]({{site.baseurl}}{% link sightseeing.md %})
 </div>
 
 <div class="content-section content-section--whitebg" markdown="1">


### PR DESCRIPTION
Closes #7 

I decided to link it at the index page and not the sightseeing page because the article includes more than just sightseeing tipps.