### PR TITLE
Update meta description, add keywords

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ title: Ruby Unconf Hamburg 2018
 email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
   Ruby Unconf 2018 takes place at the 5th and 6th of May 2018 in Hamburg, Germany.
+keywords: ruby, unconf, conference, developers, hamburg
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: rubyunconfeu

--- a/_config.yml
+++ b/_config.yml
@@ -42,4 +42,4 @@ plugins:
 #   - vendor/ruby/
 
 exclude:
-  README.md
+  - README.md

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@
 title: Ruby Unconf Hamburg 2018
 email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
-  Ruby Unconf 2018 will probably happen sometimes around May 2018. Stay tuned.
+  Ruby Unconf 2018 takes place at the 5th and 6th of May 2018 in Hamburg, Germany.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: rubyunconfeu

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,7 @@
 
 {% seo %}
     <meta name="description" content="{{ page.description | default: site.description | default: site.github.project_tagline }}"/>
+    <meta name="keywords" content="{{ page.keywords | default: site.keywords }}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#C74948">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Roboto+Mono:400|Roboto:400,700" rel="stylesheet">


### PR DESCRIPTION
This adds the date of the conference to the meta description and adds meta keywords (ruby, unconf, conference, developers, hamburg).

This changes the items exclude block in the config to an array to prevent the deprecation warning when starting the server.